### PR TITLE
Refactoring

### DIFF
--- a/rc/fzf.kak
+++ b/rc/fzf.kak
@@ -38,7 +38,38 @@ Supported tools:
 Default arguments:
     ""git ls-tree --name-only -r HEAD""
 " \
+
 str fzf_git_command "git"
+
+declare-option -docstring "command to provide list of files in svn repository to fzf. Arguments are supported
+Supported tools:
+    <package>:                  <value>:
+    Subversion:                 ""svn""
+
+Default arguments:
+    ""svn list -R . | grep -v '$/' | tr '\\n' '\\0'""
+" \
+str fzf_svn_command "svn"
+
+declare-option -docstring "command to provide list of files in mercurial repository to fzf. Arguments are supported
+Supported tools:
+    <package>:                  <value>:
+    Mercurial SCM:              ""hg""
+
+Default arguments:
+    ""hg locate -f -0 -I .hg locate -f -0 -I .""
+" \
+str fzf_hg_command "hg"
+
+declare-option -docstring "command to provide list of files in GNU Bazaar repository to fzf. Arguments are supported
+Supported tools:
+    <package>:                  <value>:
+    GNU Bazaar:                 ""bzr""
+
+Default arguments:
+    ""bzr ls -R --versioned -0""
+" \
+str fzf_bzr_command "bzr"
 
 declare-option -docstring "command to provide list of ctags to fzf. Arguments are supported
 Supported tools:

--- a/rc/fzf.kak
+++ b/rc/fzf.kak
@@ -105,9 +105,9 @@ Default arguments:
 "\
 str fzf_highlighter "highlight"
 
-declare-option -docstring "height of fzf tmux split
-Default value: 15" \
-int fzf_tmux_height 15
+declare-option -docstring "height of fzf tmux split in screen lines or percents
+Default value: 25%%" \
+str fzf_tmux_height '25%'
 
 # default mappings
 map global fzf -docstring "open buffer"                  'b' '<esc>: fzf-buffer<ret>'

--- a/rc/fzf.kak
+++ b/rc/fzf.kak
@@ -119,9 +119,9 @@ map global fzf -docstring "search in buffer"             's' '<esc>: fzf-buffer-
 map global fzf -docstring "find tag"                     't' '<esc>: fzf-tag<ret>'
 
 map global fzf-vcs -docstring "edit file from Git tree"        'g' '<esc>: fzf-git<ret>'
-map global fzf-vcs -docstring "edit file from Subversion tree" 's' '<esc>: fzf-git<ret>'
-map global fzf-vcs -docstring "edit file from mercurial tree"  'h' '<esc>: fzf-git<ret>'
-map global fzf-vcs -docstring "edit file from GNU Bazaar tree" 'b' '<esc>: fzf-git<ret>'
+map global fzf-vcs -docstring "edit file from Subversion tree" 's' '<esc>: fzf-svn<ret>'
+map global fzf-vcs -docstring "edit file from mercurial tree"  'h' '<esc>: fzf-hg<ret>'
+map global fzf-vcs -docstring "edit file from GNU Bazaar tree" 'b' '<esc>: fzf-bzr<ret>'
 
 # Commands
 define-command -docstring "Enter fzf-mode.
@@ -158,7 +158,7 @@ define-command -hidden fzf-file %{
         find*|ag*|rg*|fd*)
             cmd=$kak_opt_fzf_file_command ;;
         *)
-            executable=$(echo $kak_opt_fzf_file_command | awk '{print $1}'| tr '(' ' ' | cut -d " " -f 2)
+            executable=$(echo $kak_opt_fzf_file_command | awk '{print $1'}| tr '(' ' ' | cut -d " " -f 2)
             echo "echo -markup '{Information}''$executable'' is not supported by the script. fzf.kak may not work as you expect.'"
             cmd=$kak_opt_fzf_file_command ;;
         esac
@@ -332,7 +332,7 @@ define-command -hidden fzf -params 2..3 %{ evaluate-commands %sh{
     tmp=$(mktemp $(eval echo ${TMPDIR:-/tmp}/kak-fzf.XXXXXX))
     exec=$(mktemp $(eval echo ${TMPDIR:-/tmp}/kak-exec.XXXXXX))
 
-    if [ "$(echo $items_command | awk 'print $1')" = "edit" ] && [ $kak_opt_fzf_preview = "true" ]; then
+    if [ "$(echo $callback | awk '{print $1}')" = "edit" ] && [ $kak_opt_fzf_preview = "true" ]; then
         case $kak_opt_fzf_highlighter in
         coderay)
             highlighter="coderay {}" ;;

--- a/rc/fzf.kak
+++ b/rc/fzf.kak
@@ -11,7 +11,8 @@
 # │ different fzf commands.         │
 # ╰─────────────────────────────────╯
 
-try %{ declare-user-mode fzf } catch %{fail "Can't declare mode 'fzf' - already exists"}
+try %{ declare-user-mode fzf } catch %{echo -markup "{Error}Can't declare mode 'fzf' - already exists"}
+try %{ declare-user-mode fzf-vcs } catch %{echo -markup "{Error}Can't declare mode 'fzf-vcs' - already exists"}
 
 # Options
 declare-option -docstring "command to provide list of files to fzf. Arguments are supported
@@ -38,7 +39,6 @@ Supported tools:
 Default arguments:
     ""git ls-tree --name-only -r HEAD""
 " \
-
 str fzf_git_command "git"
 
 declare-option -docstring "command to provide list of files in svn repository to fzf. Arguments are supported
@@ -110,12 +110,18 @@ Default value: 15" \
 int fzf_tmux_height 15
 
 # default mappings
-map global fzf -docstring "open buffer"           b '<esc>: fzf-buffer<ret>'
-map global fzf -docstring "change directory"      c '<esc>: fzf-cd<ret>'
-map global fzf -docstring "open file"             f '<esc>: fzf-file<ret>'
-map global fzf -docstring "edif file in git tree" g '<esc>: fzf-git<ret>'
-map global fzf -docstring "search in buffer"      s '<esc>: fzf-buffer-search<ret>'
-map global fzf -docstring "find tag"              t '<esc>: fzf-tag<ret>'
+map global fzf -docstring "open buffer"                  'b' '<esc>: fzf-buffer<ret>'
+map global fzf -docstring "change directory"             'c' '<esc>: fzf-cd<ret>'
+map global fzf -docstring "open file"                    'f' '<esc>: fzf-file<ret>'
+map global fzf -docstring "edit file from vcs repo"      'v' '<esc>: fzf-vcs<ret>'
+map global fzf -docstring "svitch to vcs selection mode" 'V' '<esc>: fzf-vcs-mode<ret>'
+map global fzf -docstring "search in buffer"             's' '<esc>: fzf-buffer-search<ret>'
+map global fzf -docstring "find tag"                     't' '<esc>: fzf-tag<ret>'
+
+map global fzf-vcs -docstring "edit file from Git tree"        'g' '<esc>: fzf-git<ret>'
+map global fzf-vcs -docstring "edit file from Subversion tree" 's' '<esc>: fzf-git<ret>'
+map global fzf-vcs -docstring "edit file from mercurial tree"  'h' '<esc>: fzf-git<ret>'
+map global fzf-vcs -docstring "edit file from GNU Bazaar tree" 'b' '<esc>: fzf-git<ret>'
 
 # Commands
 define-command -docstring "Enter fzf-mode.
@@ -125,6 +131,14 @@ Best used with mapping like:
     map global normal '<some key>' ': fzf-mode<ret>'
 " \
 fzf-mode %{ try %{ evaluate-commands 'enter-user-mode fzf' } }
+
+define-command -docstring "Enter fzf-mode.
+fzf-mode contains mnemonic key bindings for every fzf.kak command
+
+Best used with mapping like:
+    map global normal '<some key>' ': fzf-mode<ret>'
+" \
+fzf-vcs-mode %{ try %{ evaluate-commands 'enter-user-mode fzf-vcs' } }
 
 define-command -hidden fzf-file %{
     evaluate-commands %sh{
@@ -191,6 +205,34 @@ define-command -hidden fzf-file %{
     }
 }
 
+define-command -hidden fzf-vcs %{
+    evaluate-commands %sh{
+        commands="git rev-parse --is-inside-work-tree
+svn info
+hg --cwd . root
+bzr status"
+        IFS='
+'
+        for cmd in $commands; do
+            eval $cmd >/dev/null 2>&1
+            res=$?
+            if [ "$res"  = "0" ]; then
+                vcs=$(echo $cmd | awk '{print $1}')
+                title="fzf $vcs"
+                [ ! -z "${kak_client_env_TMUX}" ] && additional_keybindings="
+<c-s>: open file in horizontal split
+<c-v>: open file in vertical split"
+                message="Open single or multiple files from git tree.
+<ret>: open file in new buffer.
+<c-w>: open file in new window $additional_keybindings"
+                echo "info -title '$title' '$message'"
+                echo "fzf-$vcs"
+                break
+            fi
+        done
+    }
+}
+
 define-command -hidden fzf-git %{
     evaluate-commands %sh{
         case $kak_opt_fzf_git_command in
@@ -200,44 +242,53 @@ define-command -hidden fzf-git %{
         git*)
             cmd=$kak_opt_fzf_git_command
             ;;
-        *)
-            echo "echo -markup '{Information}$kak_opt_fzf_git_command vcs is not supported by the script. fzf.kak may not work as you expect."
-            cmd=$kak_opt_fzf_git_command
+        esac
+        [ ! -z "${kak_client_env_TMUX}" ] && additional_flags="--expect ctrl-v --expect ctrl-s"
+        eval echo 'fzf \"edit \$1\" \"$cmd\" \"-m --expect ctrl-w $additional_flags\"'
+    }
+}
+
+define-command -hidden fzf-hg %{
+    evaluate-commands %sh{
+        case $kak_opt_fzf_hg_command in
+        hg)
+            cmd="hg locate -f -0 -I .hg locate -f -0 -I ."
+            ;;
+        hg*)
+            cmd=$kak_opt_fzf_hg_command
             ;;
         esac
-        title="fzf git"
-        [ ! -z "${kak_client_env_TMUX}" ] && additional_keybindings="
-<c-s>: open file in horizontal split
-<c-v>: open file in vertical split"
-        message="Open single or multiple files from git tree.
-<ret>: open file in new buffer.
-<c-w>: open file in new window $additional_keybindings"
-        echo "info -title '$title' '$message'"
         [ ! -z "${kak_client_env_TMUX}" ] && additional_flags="--expect ctrl-v --expect ctrl-s"
-        if [ $kak_opt_fzf_preview = "true" ]; then
-            case $kak_opt_fzf_highlighter in
-            coderay)
-                highlighter="coderay {}"
-                ;;
-            highlight)
-                highlighter="highlight --failsafe -O ansi {}"
-                ;;
-            rouge)
-                highlighter="rougify {}"
-                ;;
-            coderay*|highlight*|rougify*)
-                highlighter=$kak_opt_fzf_highlighter
-                ;;
-            *)
-                executable=$(echo $kak_opt_fzf_highlighter | awk '{print $1}'| tr '(' ' ' | cut -d " " -f 2)
-                echo "echo -markup '{Information}''$executable'' highlighter is not supported by the script. fzf.kak may not work as you expect.'"
-                highlighter=$kak_opt_fzf_highlighter
-                ;;
-            esac
-            cmd="sleep 0.1; if [ \$(tput cols) -gt \$(expr \$(tput lines) \\* 2) ]; then pos=right:50%%; else pos=top:60%%; fi; $cmd"
-            preview_opt="--preview '($highlighter || cat {}) 2>/dev/null | head -n $kak_opt_fzf_preview_lines' --preview-window=\$pos"
-            additional_flags="$preview_opt $additional_flags"
-        fi
+        eval echo 'fzf \"edit \$1\" \"$cmd\" \"-m --expect ctrl-w $additional_flags\"'
+    }
+}
+
+define-command -hidden fzf-svn %{
+    evaluate-commands %sh{
+        case $kak_opt_fzf_svn_command in
+        svn)
+            cmd="svn list -R . | grep -v '$/' | tr '\\n' '\\0'"
+            ;;
+        svn*)
+            cmd=$kak_opt_fzf_svn_command
+            ;;
+        esac
+        [ ! -z "${kak_client_env_TMUX}" ] && additional_flags="--expect ctrl-v --expect ctrl-s"
+        eval echo 'fzf \"edit \$1\" \"$cmd\" \"-m --expect ctrl-w $additional_flags\"'
+    }
+}
+
+define-command -hidden fzf-bzr %{
+    evaluate-commands %sh{
+        case $kak_opt_fzf_bzr_command in
+        bzr)
+            cmd="bzr ls -R --versioned -0"
+            ;;
+        bzr*)
+            cmd=$kak_opt_fzf_bzr_command
+            ;;
+        esac
+        [ ! -z "${kak_client_env_TMUX}" ] && additional_flags="--expect ctrl-v --expect ctrl-s"
         eval echo 'fzf \"edit \$1\" \"$cmd\" \"-m --expect ctrl-w $additional_flags\"'
     }
 }

--- a/rc/fzf.kak
+++ b/rc/fzf.kak
@@ -43,8 +43,8 @@ str fzf_git_command "git"
 
 declare-option -docstring "command to provide list of files in svn repository to fzf. Arguments are supported
 Supported tools:
-    <package>:                  <value>:
-    Subversion:                 ""svn""
+    <package>:  <value>:
+    Subversion: ""svn""
 
 Default arguments:
     ""svn list -R . | grep -v '$/' | tr '\\n' '\\0'""
@@ -53,8 +53,8 @@ str fzf_svn_command "svn"
 
 declare-option -docstring "command to provide list of files in mercurial repository to fzf. Arguments are supported
 Supported tools:
-    <package>:                  <value>:
-    Mercurial SCM:              ""hg""
+    <package>:     <value>:
+    Mercurial SCM: ""hg""
 
 Default arguments:
     ""hg locate -f -0 -I .hg locate -f -0 -I .""
@@ -63,8 +63,8 @@ str fzf_hg_command "hg"
 
 declare-option -docstring "command to provide list of files in GNU Bazaar repository to fzf. Arguments are supported
 Supported tools:
-    <package>:                  <value>:
-    GNU Bazaar:                 ""bzr""
+    <package>:  <value>:
+    GNU Bazaar: ""bzr""
 
 Default arguments:
     ""bzr ls -R --versioned -0""
@@ -83,9 +83,9 @@ str fzf_tag_command "readtags"
 
 declare-option -docstring "allow showing preview window
 Default value:
-    false
+    true
 " \
-bool fzf_preview false
+bool fzf_preview true
 
 declare-option -docstring "amount of lines to pass to preview window
 Default value: 100" \
@@ -148,25 +148,19 @@ define-command -hidden fzf-file %{
         fi
         case $kak_opt_fzf_file_command in
         find)
-            cmd="find -type f"
-            ;;
+            cmd="find -type f" ;;
         ag)
-            cmd="ag -l -f --hidden --one-device . "
-            ;;
+            cmd="ag -l -f --hidden --one-device . " ;;
         rg)
-            cmd="rg -L --hidden --files"
-            ;;
+            cmd="rg -L --hidden --files" ;;
         fd)
-            cmd="fd --type f --follow"
-            ;;
+            cmd="fd --type f --follow" ;;
         find*|ag*|rg*|fd*)
-            cmd=$kak_opt_fzf_file_command
-            ;;
+            cmd=$kak_opt_fzf_file_command ;;
         *)
             executable=$(echo $kak_opt_fzf_file_command | awk '{print $1}'| tr '(' ' ' | cut -d " " -f 2)
             echo "echo -markup '{Information}''$executable'' is not supported by the script. fzf.kak may not work as you expect.'"
-            cmd=$kak_opt_fzf_file_command
-            ;;
+            cmd=$kak_opt_fzf_file_command ;;
         esac
         title="fzf file"
         [ ! -z "${kak_client_env_TMUX}" ] && additional_keybindings="
@@ -177,35 +171,20 @@ define-command -hidden fzf-file %{
 <c-w>: open file in new window $additional_keybindings"
         echo "info -title '$title' '$message'"
         [ ! -z "${kak_client_env_TMUX}" ] && additional_flags="--expect ctrl-v --expect ctrl-s"
-        if [ $kak_opt_fzf_preview = "true" ]; then
-            case $kak_opt_fzf_highlighter in
-            coderay)
-                highlighter="coderay {}"
-                ;;
-            highlight)
-                highlighter="highlight --failsafe -O ansi {}"
-                ;;
-            rouge)
-                highlighter="rougify {}"
-                ;;
-            coderay*|highlight*|rougify*)
-                highlighter=$kak_opt_fzf_highlighter
-                ;;
-            *)
-                executable=$(echo $kak_opt_fzf_highlighter | awk '{print $1}'| tr '(' ' ' | cut -d " " -f 2)
-                echo "echo -markup '{Information}''$executable'' highlighter is not supported by the script. fzf.kak may not work as you expect.'"
-                highlighter=$kak_opt_fzf_highlighter
-                ;;
-            esac
-            cmd="sleep 0.1; if [ \$(tput cols) -gt \$(expr \$(tput lines) \\* 2) ]; then pos=right:50%%; else pos=top:60%%; fi; $cmd"
-            preview_opt="--preview '($highlighter || cat {}) 2>/dev/null | head -n $kak_opt_fzf_preview_lines' --preview-window=\$pos"
-            additional_flags="$preview_opt $additional_flags"
-        fi
         eval echo 'fzf \"edit \$1\" \"$cmd\" \"-m --expect ctrl-w $additional_flags\"'
     }
 }
 
-define-command -hidden fzf-vcs %{
+define-command -docstring "Wrapper command for fzf vcs to automatically decect
+used version control system.
+
+Supported vcs:
+    Git --fast-version-control: ""git""
+    Subversion:                 ""svn""
+    Mercurial SCM:              ""hg""
+    GNU Bazaar:                 ""bzr""
+" \
+-hidden fzf-vcs %{
     evaluate-commands %sh{
         commands="git rev-parse --is-inside-work-tree
 svn info
@@ -297,15 +276,12 @@ define-command -hidden fzf-tag %{
     evaluate-commands %sh{
         case $kak_opt_fzf_tag_command in
         readtags)
-            cmd="readtags -l | cut -f1 | sort -u"
-            ;;
+            cmd="readtags -l | cut -f1 | sort -u" ;;
         readtags*)
-            cmd=$kak_opt_fzf_tag_command
-            ;;
+            cmd=$kak_opt_fzf_tag_command ;;
         *)
             echo "echo -markup '{Information}$kak_opt_fzf_tag_command is not supported by the script. fzf.kak may not work as you expect."
-            cmd=$kak_opt_fzf_tag_command
-            ;;
+            cmd=$kak_opt_fzf_tag_command ;;
         esac
         title="fzf tag"
         [ ! -z "${kak_client_env_TMUX}" ] && additional_keybindings="
@@ -338,9 +314,7 @@ define-command -hidden fzf-buffer-search %{
         buffer_content=$(mktemp ${TMPDIR:-/tmp}/kak-curr-buff.XXXXXX)
         echo "execute-keys %{%<a-|>cat<space>><space>$buffer_content<ret>;}"
         echo "execute-keys $line g $char l"
-        echo "fzf \"execute-keys \$1 gx\" \"(nl -b a -n ln $buffer_content\" \"--reverse | cut -f 1)\""
-        # sleep 1 is needed to because everything is done asynchronously, so file should not be deleted until it was read by fzf
-        echo "nop %sh{sleep 1; rm $buffer_content}"
+        echo "fzf \"execute-keys \$1 gx\" \"(nl -b a -n ln $buffer_content\" \"--reverse | cut -f 1; rm $buffer_content)\""
     }
 }
 
@@ -349,7 +323,6 @@ define-command -hidden fzf -params 2..3 %{ evaluate-commands %sh{
     items_command=$2
     additional_flags=$3
 
-    # 'tr' - if '(cmd1 && cmd2) | fzf' was passed 'awk' will return '(cmd1'
     items_executable=$(echo $items_command | awk '{print $1}' | tr '(' ' ' | cut -d " " -f 2)
     if [ -z $(command -v $items_executable) ]; then
         echo "fail \'$items_executable' executable not found"
@@ -359,12 +332,35 @@ define-command -hidden fzf -params 2..3 %{ evaluate-commands %sh{
     tmp=$(mktemp $(eval echo ${TMPDIR:-/tmp}/kak-fzf.XXXXXX))
     exec=$(mktemp $(eval echo ${TMPDIR:-/tmp}/kak-exec.XXXXXX))
 
+    if [ "$(echo $items_command | awk 'print $1')" = "edit" ] && [ $kak_opt_fzf_preview = "true" ]; then
+        case $kak_opt_fzf_highlighter in
+        coderay)
+            highlighter="coderay {}" ;;
+        highlight)
+            highlighter="highlight --failsafe -O ansi {}" ;;
+        rouge)
+            highlighter="rougify {}" ;;
+        coderay*|highlight*|rougify*)
+            highlighter=$kak_opt_fzf_highlighter ;;
+        *)
+            executable=$(echo $kak_opt_fzf_highlighter | awk '{print $1}'| tr '(' ' ' | cut -d " " -f 2)
+            echo "echo -markup '{Information}''$executable'' highlighter is not supported by the script. fzf.kak may not work as you expect.'"
+            highlighter=$kak_opt_fzf_highlighter ;;
+        esac
+        if [ ! -z "${kak_client_env_TMUX}" ]; then
+            preview_pos='pos=right:50%;'
+        else
+            preview_pos='sleep 0.1; if [ $(tput cols) -gt $(expr $(tput lines) * 2) ]; then pos=right:50%; else pos=top:60%; fi;'
+        fi
+        additional_flags="--preview '($highlighter || cat {}) 2>/dev/null | head -n $kak_opt_fzf_preview_lines' --preview-window=\$pos $additional_flags"
+    fi
+
     if [ ! -z "${kak_client_env_TMUX}" ]; then
-        cmd="$items_command | fzf-tmux -d $kak_opt_fzf_tmux_height --expect ctrl-q $additional_flags > $tmp"
+        cmd="$preview_pos $items_command | fzf-tmux -d $kak_opt_fzf_tmux_height --expect ctrl-q $additional_flags > $tmp"
     elif [ ! -z "${kak_opt_termcmd}" ]; then
         path=$(pwd)
         additional_flags=$(echo $additional_flags | sed "s:\$pos:\\\\\$pos:")
-        cmd="$kak_opt_termcmd \"sh -c \\\"cd $path && $items_command | fzf --expect ctrl-q $additional_flags > $tmp\\\"\""
+        cmd="$kak_opt_termcmd \"sh -c \\\"cd $path && $preview_pos $items_command | fzf --expect ctrl-q $additional_flags > $tmp\\\"\""
     else
         echo "fail termcmd option is not set"
         exit


### PR DESCRIPTION
**Breaking change**: sort of
Replaces fzf-mode `g` mapping with `v` mapping
<!-- Please provide meaningful description about your contribution -->
**Description**:
* New fzf-vcs command, that is now a default command to use inside any version contrrol system. It automatically detects vcs type, and executes file command over it;
* New preview behavior: in tmux, preview will always stay at right position;
* Tmux split size increased to 25% of window's height;
* New submode: fzf-mode V mapping, that lets you choose which vcs command you want to run
* Buffer search no longer sleeps, and deletes tmp buffer only after search is done.

<!-- note that code will be reviewed and changes much likely will be requested -->
