### PR TITLE
default find is compatible on both gnu and bsd

### DIFF
--- a/rc/fzf-modules/fzf-cd.kak
+++ b/rc/fzf-modules/fzf-cd.kak
@@ -10,7 +10,7 @@
 
 declare-option -docstring "command to provide list of directories to fzf.
 Default value:
-    find: (echo .. && find \( -path '*/.svn*' -o -path '*/.git*' \) -prune -o -type d -print)
+    find: (echo .. && find . \( -path '*/.svn*' -o -path '*/.git*' \) -prune -o -type d -print)
 " \
 str fzf_cd_command "find"
 
@@ -37,7 +37,7 @@ define-command -hidden fzf-cd %{ evaluate-commands %sh{
 
     case $kak_opt_fzf_cd_command in
         find)
-            items_command="(echo .. && find \( -path '*/.svn*' -o -path '*/.git*' \) -prune -o -type d -print)" ;;
+            items_command="(echo .. && find . \( -path '*/.svn*' -o -path '*/.git*' \) -prune -o -type d -print)" ;;
         *)
             items_command=$kak_opt_fzf_cd_command ;;
     esac

--- a/rc/fzf-modules/fzf-file.kak
+++ b/rc/fzf-modules/fzf-file.kak
@@ -17,7 +17,7 @@ Supported tools:
     fd:                  ""fd""
 
 Default arguments:
-    find: ""find -type f -follow""
+    find: ""find -L . -type f""
     ag:   ""ag -l -f --hidden --one-device .""
     rg:   ""rg -L --hidden --files""
     fd:   ""fd --type f --follow""
@@ -33,7 +33,7 @@ define-command -hidden fzf-file %{ evaluate-commands %sh{
     fi
     case $kak_opt_fzf_file_command in
     find)
-        cmd="find -type f -follow" ;;
+        cmd="find -L . -type f" ;;
     ag)
         cmd="ag -l -f --hidden --one-device . " ;;
     rg)


### PR DESCRIPTION
**Breaking change**: no
<!-- Please provide meaningful description about your contribution -->
**Description**:
At the moment none of the find commands works on Mac.
This pr alters default find commands a little bit so fzf plugin works on Mac and Linux out of the box.
I've tested on arch Linux as well, there is no breaking changes.

<!-- note that code will be reviewed and changes much likely will be requested -->
