### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ option to `false`.
 
 #### Highlighting preview window
 You also can highlight contents of the file displayed within preview window. To
-do so, you can specify which highlighter to use with `fzf_highlighter` option.
+do so, you can specify which highlighter to use with `fzf_highlight_cmd` option.
 Supported highlighters are:
 
 * [Bat][16]


### PR DESCRIPTION


**Breaking change**: no
<!-- Please provide meaningful description about your contribution -->
**Description**:
The option to change the preview highlighter is called `fzf_highlight_cmd`, not `fzf_highlighter`.
This fixes the readme

<!-- note that code will be reviewed and changes much likely will be requested -->
