### PR TITLE
Send errors away

### DIFF
--- a/rc/modules/fzf-file.kak
+++ b/rc/modules/fzf-file.kak
@@ -49,7 +49,7 @@ define-command -hidden fzf-file %{ evaluate-commands %sh{
         cmd=$kak_opt_fzf_file_command ;;
     esac
 
-    cmd=$cmd" 2>/dev/null"
+    cmd="$cmd 2>/dev/null"
     message="Open single or multiple files.
 <ret>: open file in new buffer.
 <c-w>: open file in new terminal"

--- a/rc/modules/fzf-file.kak
+++ b/rc/modules/fzf-file.kak
@@ -49,6 +49,7 @@ define-command -hidden fzf-file %{ evaluate-commands %sh{
         cmd=$kak_opt_fzf_file_command ;;
     esac
 
+    cmd=$cmd" 2>/dev/null"
     message="Open single or multiple files.
 <ret>: open file in new buffer.
 <c-w>: open file in new terminal"


### PR DESCRIPTION
Find worked wihtout this, `rg` keeps throwing errors about file operation not permitted when it goes searching into the Trash folder...

**Breaking change**: no
<!-- Please provide meaningful description about your contribution -->
**Description**:


<!-- note that code will be reviewed and changes much likely will be requested -->
