### PR TITLE
V1.1.0 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ fzf` before configuring options. Same goes for `fzf_vcs` module.
 From now on I assume that you're using one of the methods listed above for all
 configurations below.
 
+### Windowing
+If you're using Tmux, you do not have to worry about windowing, since fzf.kak
+automatically creates all needed Tmux splits and panes for you. However in case
+you're not using Tmux, fzf.kak uses `fzf_terminal_cmd` option to call windowing
+command to create new windows. By default it is set to use `terminal` alias:
+`terminal kak -c %val{session} -e "%arg{@}"`, but some terminals can provide
+other aliases or commands, like `terminal-tab` in Kitty. You may want to edit
+this variable accordingly to your personal preferences.
+
 ### Mappings
 You can define what keys to use in `fzf` window via these options:
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ configurations below.
 ### Windowing
 If you're using Tmux, you do not have to worry about windowing, since fzf.kak
 automatically creates all needed Tmux splits and panes for you. However in case
-you're not using Tmux, fzf.kak uses `fzf_terminal_cmd` option to call windowing
+you're not using Tmux, fzf.kak uses `fzf_terminal_command` option to call windowing
 command to create new windows. By default it is set to use `terminal` alias:
 `terminal kak -c %val{session} -e "%arg{@}"`, but some terminals can provide
 other aliases or commands, like `terminal-tab` in Kitty. You may want to edit
@@ -180,7 +180,7 @@ option to `false`.
 
 #### Highlighting preview window
 You also can highlight contents of the file displayed within preview window. To
-do so, you can specify which highlighter to use with `fzf_highlight_cmd` option.
+do so, you can specify which highlighter to use with `fzf_highlight_command` option.
 Supported highlighters are:
 
 * [Bat][16]

--- a/rc/fzf.kak
+++ b/rc/fzf.kak
@@ -57,7 +57,7 @@ These are default arguments for the tools above:
     highlight: "highlight --failsafe -O ansi {}"
     rouge:     "rougify {}"
 ' \
-str fzf_highlight_cmd "highlight"
+str fzf_highlight_command "highlight"
 
 declare-option -docstring "height of fzf tmux split in screen lines or percents.
 Default value: 25%%" \
@@ -87,7 +87,7 @@ str fzf_horizontal_map 'ctrl-s'
 declare-option -docstring 'command to use to create new window when not using tmux.
 
 Default value: terminal kak -c %val{session} -e "%arg{@}"' \
-str fzf_terminal_cmd 'terminal kak -c %val{session} -e "%arg{@}"'
+str fzf_terminal_command 'terminal kak -c %val{session} -e "%arg{@}"'
 
 try %{ declare-user-mode fzf }
 
@@ -106,7 +106,7 @@ fzf-window -params .. %{ evaluate-commands %sh{
     if [ -n "$kak_client_env_TMUX" ]; then
         printf "%s\n" 'tmux-terminal-window kak -c %val{session} -e "%arg{@}"'
     else
-        printf "%s\n" "$kak_opt_fzf_terminal_cmd"
+        printf "%s\n" "$kak_opt_fzf_terminal_command"
     fi
 }}
 
@@ -167,12 +167,12 @@ fzf -params .. %{ evaluate-commands %sh{
 
         # handle preview if not defined explicitly with `-preview-cmd'
         if [ ${kak_opt_fzf_preview} = "true" ] && [ -z "${preview_cmd}" ]; then
-            case ${kak_opt_fzf_highlight_cmd} in
+            case ${kak_opt_fzf_highlight_command} in
                 (bat)       highlight_cmd="bat --color=always --style=plain {}" ;;
                 (coderay)   highlight_cmd="coderay {}" ;;
                 (highlight) highlight_cmd="highlight --failsafe -O ansi {}" ;;
                 (rouge)     highlight_cmd="rougify {}" ;;
-                (*)         highlight_cmd="${kak_opt_fzf_highlight_cmd}" ;;
+                (*)         highlight_cmd="${kak_opt_fzf_highlight_command}" ;;
             esac
             preview_cmd="--preview '(${highlight_cmd} || cat {}) 2>/dev/null | head -n ${kak_opt_fzf_preview_lines}' --preview-window=\${pos}"
         fi
@@ -204,7 +204,7 @@ fzf -params .. %{ evaluate-commands %sh{
         # `terminal' doesn't support any kind of width and height parameters, so tmux panes are created by tmux itself
         cmd="nop %sh{ command tmux split-window ${measure} ${tmux_height%%%*} '${fzfcmd}' }"
     else
-        cmd="${kak_opt_fzf_terminal_cmd%% *} %{${fzfcmd}}"
+        cmd="${kak_opt_fzf_terminal_command%% *} %{${fzfcmd}}"
     fi
 
     printf "%s\n" "${cmd}"

--- a/rc/fzf.kak
+++ b/rc/fzf.kak
@@ -139,16 +139,17 @@ fzf -params .. %{ evaluate-commands %sh{
 
     while [ $# -gt 0 ]; do
         case $1 in
-            -kak-cmd)      shift; kakoune_cmd="$1"  ;;
-            -multiple-cmd) shift; multiple_cmd="$1" ;;
-            -items-cmd)    shift; items_cmd="$1 |"  ;;
-            -fzf-impl)     shift; fzf_impl="$1"     ;;
-            -fzf-args)     shift; fzf_args="$1"     ;;
-            -preview-cmd)  shift; preview_cmd="$1"  ;;
-            -preview)             preview="true"    ;;
-            -filter)       shift; filter="| $1"     ;;
-            -post-action)  shift; post_action="$1"  ;;
-        esac; shift
+            (-kak-cmd)      shift; kakoune_cmd="$1"  ;;
+            (-multiple-cmd) shift; multiple_cmd="$1" ;;
+            (-items-cmd)    shift; items_cmd="$1 |"  ;;
+            (-fzf-impl)     shift; fzf_impl="$1"     ;;
+            (-fzf-args)     shift; fzf_args="$1"     ;;
+            (-preview-cmd)  shift; preview_cmd="$1"  ;;
+            (-preview)             preview="true"    ;;
+            (-filter)       shift; filter="| $1"     ;;
+            (-post-action)  shift; post_action="$1"  ;;
+        esac
+        shift
     done
 
     [ -z "$multiple_cmd" ] && multiple_cmd="$kakoune_cmd"
@@ -157,11 +158,11 @@ fzf -params .. %{ evaluate-commands %sh{
         # bake position option to define them at runtime
         [ -n "${kak_client_env_TMUX}" ] && tmux_height="${kak_opt_fzf_preview_tmux_height}"
         case ${kak_opt_fzf_preview_pos} in
-            (top|up) preview_position="pos=top:${kak_opt_fzf_preview_height};" ;;
+            (top|up)      preview_position="pos=top:${kak_opt_fzf_preview_height};" ;;
             (bottom|down) preview_position="pos=down:${kak_opt_fzf_preview_height};" ;;
-            (right) preview_position="pos=right:${kak_opt_fzf_preview_width};" ;;
-            (left) preview_position="pos=left:${kak_opt_fzf_preview_width};" ;;
-            (auto|*) preview_position="sleep 0.1; [ \$(tput cols) -gt \$(expr \$(tput lines) \* 2) ] && pos=right:${kak_opt_fzf_preview_width} || pos=top:${kak_opt_fzf_preview_height};"
+            (right)       preview_position="pos=right:${kak_opt_fzf_preview_width};" ;;
+            (left)        preview_position="pos=left:${kak_opt_fzf_preview_width};" ;;
+            (auto|*)      preview_position="sleep 0.1; [ \$(tput cols) -gt \$(expr \$(tput lines) \* 2) ] && pos=right:${kak_opt_fzf_preview_width} || pos=top:${kak_opt_fzf_preview_height};"
         esac
 
         # handle preview if not defined explicitly with `-preview-cmd'

--- a/rc/fzf.kak
+++ b/rc/fzf.kak
@@ -84,34 +84,29 @@ str fzf_vertical_map 'ctrl-v'
 declare-option -docstring "mapping to execute action in new horizontal split" \
 str fzf_horizontal_map 'ctrl-s'
 
+declare-option -docstring 'command to use to create new window when not using tmux.
+
+Default value: terminal kak -c %val{session} -e "%arg{@}"' \
+str fzf_terminal_cmd 'terminal kak -c %val{session} -e "%arg{@}"'
+
 try %{ declare-user-mode fzf }
 
 define-command -hidden -docstring "wrapper command to create new vertical split" \
-fzf-vertical -params .. %{ try %{
+fzf-vertical -params .. %{ evaluate-commands %{
     tmux-terminal-vertical kak -c %val{session} -e "%arg{@}"
-} catch %{
-    tmux-new-vertical "%arg{@}"
 }}
 
 define-command -hidden -docstring "wrapper command to create new horizontal split" \
-fzf-horizontal -params .. %{ try %{
+fzf-horizontal -params .. %{ evaluate-commands %{
     tmux-terminal-horizontal kak -c %val{session} -e "%arg{@}"
-} catch %{
-    tmux-new-horizontal "%arg{@}"
 }}
 
 define-command -hidden -docstring "wrapper command to create new terminal" \
-fzf-window -params .. %{ try %sh{
+fzf-window -params .. %{ evaluate-commands %sh{
     if [ -n "$kak_client_env_TMUX" ]; then
         printf "%s\n" 'tmux-terminal-window kak -c %val{session} -e "%arg{@}"'
     else
-        printf "%s\n" 'terminal kak -c %val{session} -e "%arg{@}"'
-    fi
-} catch %sh{
-    if [ -n "$kak_client_env_TMUX" ]; then
-        printf "%s\n" 'tmux-new-window "%arg{@}"'
-    else
-        printf "%s\n" 'new "%arg{@}"'
+        printf "%s\n" "$kak_opt_fzf_terminal_cmd"
     fi
 }}
 
@@ -162,21 +157,21 @@ fzf -params .. %{ evaluate-commands %sh{
         # bake position option to define them at runtime
         [ -n "${kak_client_env_TMUX}" ] && tmux_height="${kak_opt_fzf_preview_tmux_height}"
         case ${kak_opt_fzf_preview_pos} in
-            top|up) preview_position="pos=top:${kak_opt_fzf_preview_height};" ;;
-            bottom|down) preview_position="pos=down:${kak_opt_fzf_preview_height};" ;;
-            right) preview_position="pos=right:${kak_opt_fzf_preview_width};" ;;
-            left) preview_position="pos=left:${kak_opt_fzf_preview_width};" ;;
-            auto|*) preview_position="sleep 0.1; [ \$(tput cols) -gt \$(expr \$(tput lines) \* 2) ] && pos=right:${kak_opt_fzf_preview_width} || pos=top:${kak_opt_fzf_preview_height};"
+            (top|up) preview_position="pos=top:${kak_opt_fzf_preview_height};" ;;
+            (bottom|down) preview_position="pos=down:${kak_opt_fzf_preview_height};" ;;
+            (right) preview_position="pos=right:${kak_opt_fzf_preview_width};" ;;
+            (left) preview_position="pos=left:${kak_opt_fzf_preview_width};" ;;
+            (auto|*) preview_position="sleep 0.1; [ \$(tput cols) -gt \$(expr \$(tput lines) \* 2) ] && pos=right:${kak_opt_fzf_preview_width} || pos=top:${kak_opt_fzf_preview_height};"
         esac
 
         # handle preview if not defined explicitly with `-preview-cmd'
         if [ ${kak_opt_fzf_preview} = "true" ] && [ -z "${preview_cmd}" ]; then
             case ${kak_opt_fzf_highlight_cmd} in
-                bat)       highlight_cmd="bat --color=always --style=plain {}" ;;
-                coderay)   highlight_cmd="coderay {}" ;;
-                highlight) highlight_cmd="highlight --failsafe -O ansi {}" ;;
-                rouge)     highlight_cmd="rougify {}" ;;
-                *)         highlight_cmd="${kak_opt_fzf_highlight_cmd}" ;;
+                (bat)       highlight_cmd="bat --color=always --style=plain {}" ;;
+                (coderay)   highlight_cmd="coderay {}" ;;
+                (highlight) highlight_cmd="highlight --failsafe -O ansi {}" ;;
+                (rouge)     highlight_cmd="rougify {}" ;;
+                (*)         highlight_cmd="${kak_opt_fzf_highlight_cmd}" ;;
             esac
             preview_cmd="--preview '(${highlight_cmd} || cat {}) 2>/dev/null | head -n ${kak_opt_fzf_preview_lines}' --preview-window=\${pos}"
         fi
@@ -208,7 +203,7 @@ fzf -params .. %{ evaluate-commands %sh{
         # `terminal' doesn't support any kind of width and height parameters, so tmux panes are created by tmux itself
         cmd="nop %sh{ command tmux split-window ${measure} ${tmux_height%%%*} '${fzfcmd}' }"
     else
-        cmd="terminal %{${fzfcmd}}"
+        cmd="${kak_opt_fzf_terminal_cmd%% *} %{${fzfcmd}}"
     fi
 
     printf "%s\n" "${cmd}"
@@ -219,22 +214,26 @@ fzf -params .. %{ evaluate-commands %sh{
             (
                 while read -r line; do
                     case ${line} in
-                        ${kak_opt_fzf_window_map})     wincmd="fzf-window"     ;;
-                        ${kak_opt_fzf_vertical_map})   wincmd="fzf-vertical"   ;;
-                        ${kak_opt_fzf_horizontal_map}) wincmd="fzf-horizontal" ;;
-                        *)                             item=${line} ;;
+                        (${kak_opt_fzf_window_map})     wincmd="fzf-window"     ;;
+                        (${kak_opt_fzf_vertical_map})   wincmd="fzf-vertical"   ;;
+                        (${kak_opt_fzf_horizontal_map}) wincmd="fzf-horizontal" ;;
+                        (*)                             item=${line} ;;
                     esac
                     if [ -n "${item}" ]; then
                         item=$(printf "%s\n" "${item}" | sed "s/@/@@/g;s/&/&&/g")
+                        kakoune_cmd=$(printf "%s\n" "${kakoune_cmd}" | sed "s/&/&&/g")
                         printf "%s\n" "evaluate-commands -client ${kak_client} ${wincmd} %&${kakoune_cmd} %@${item}@&"
                         break
                     fi
                 done
+                [ -n "${multiple_cmd}" ] && multiple_cmd=$(printf "%s\n" "${multiple_cmd}" | sed "s/&/&&/g")
                 while read -r line; do
-                    printf "%s\n" "evaluate-commands -client ${kak_client} ${wincmd} %{${multiple_cmd} %{${line}}}"
+                    line=$(printf "%s\n" "${line}" | sed "s/@/@@/g;s/&/&&/g")
+                    printf "%s\n" "evaluate-commands -client ${kak_client} ${wincmd} %&${multiple_cmd} %@${line}@&"
                 done
                 if [ -n "${post_action}" ]; then
-                    printf "%s\n" "evaluate-commands -client ${kak_client} %{${post_action}}"
+                    post_action=$(printf "%s\n" "${post_action}" | sed "s/&/&&/g")
+                    printf "%s\n" "evaluate-commands -client ${kak_client} %&${post_action}&"
                 fi
             ) < ${result} | kak -p ${kak_session}
         fi

--- a/rc/modules/VCS/fzf-bzr.kak
+++ b/rc/modules/VCS/fzf-bzr.kak
@@ -25,10 +25,8 @@ define-command -hidden fzf-bzr %{ evaluate-commands %sh{
     current_path=$(pwd)
     repo_root=$(bzr root)
     case $kak_opt_fzf_bzr_command in
-    bzr)
-        cmd="bzr ls -R --versioned -0" ;;
-    bzr*)
-        cmd=$kak_opt_fzf_bzr_command ;;
+        (bzr)  cmd="bzr ls -R --versioned -0" ;;
+        (bzr*) cmd=$kak_opt_fzf_bzr_command ;;
     esac
     [ ! -z "${kak_client_env_TMUX}" ] && additional_flags="--expect $kak_opt_fzf_vertical_map --expect $kak_opt_fzf_horizontal_map"
     printf "%s\n" "fzf -kak-cmd %{cd $repo_root; edit -existing} -items-cmd %{$cmd} -fzf-args %{-m --expect $kak_opt_fzf_window_map $additional_flags} -post-action %{cd $current_path}"

--- a/rc/modules/VCS/fzf-git.kak
+++ b/rc/modules/VCS/fzf-git.kak
@@ -25,10 +25,8 @@ define-command -override -hidden fzf-git %{ evaluate-commands %sh{
     current_path=$(pwd)
     repo_root=$(git rev-parse --show-toplevel)
     case $kak_opt_fzf_git_command in
-    git)
-        cmd="git ls-tree --full-tree --name-only -r HEAD" ;;
-    git*)
-        cmd=$kak_opt_fzf_git_command ;;
+        (git)  cmd="git ls-tree --full-tree --name-only -r HEAD" ;;
+        (git*) cmd=$kak_opt_fzf_git_command ;;
     esac
     [ ! -z "${kak_client_env_TMUX}" ] && additional_flags="--expect $kak_opt_fzf_vertical_map --expect $kak_opt_fzf_horizontal_map"
     printf "%s\n" "fzf -kak-cmd %{cd $repo_root; edit -existing} -items-cmd %{$cmd} -fzf-args %{-m --expect $kak_opt_fzf_window_map $additional_flags} -post-action %{cd $current_path}"

--- a/rc/modules/VCS/fzf-hg.kak
+++ b/rc/modules/VCS/fzf-hg.kak
@@ -25,10 +25,8 @@ define-command -hidden fzf-hg %{ evaluate-commands %sh{
     current_path=$(pwd)
     repo_root=$(hg root)
     case $kak_opt_fzf_hg_command in
-    hg)
-        cmd="hg locate -f -0 -I .hg locate -f -0 -I ." ;;
-    hg*)
-        cmd=$kak_opt_fzf_hg_command ;;
+        (hg)  cmd="hg locate -f -0 -I .hg locate -f -0 -I ." ;;
+        (hg*) cmd=$kak_opt_fzf_hg_command ;;
     esac
     [ ! -z "${kak_client_env_TMUX}" ] && additional_flags="--expect $kak_opt_fzf_vertical_map --expect $kak_opt_fzf_horizontal_map"
     printf "%s\n" "fzf -kak-cmd %{cd $repo_root; edit -existing} -items-cmd %{$cmd} -fzf-args %{-m --expect $kak_opt_fzf_window_map $additional_flags} -post-action %{cd $current_path}"

--- a/rc/modules/VCS/fzf-svn.kak
+++ b/rc/modules/VCS/fzf-svn.kak
@@ -25,10 +25,8 @@ define-command -hidden fzf-svn %{ evaluate-commands %sh{
     current_path=$(pwd)
     repo_root=$(svn info | awk -F': ' '/Working Copy Root Path: .*/ {print $2}')
     case $kak_opt_fzf_svn_command in
-    svn)
-        cmd="svn list -R $repo_root | grep -v '$/'" ;;
-    svn*)
-        cmd=$kak_opt_fzf_svn_command ;;
+        (svn)  cmd="svn list -R $repo_root | grep -v '$/'" ;;
+        (svn*) cmd=$kak_opt_fzf_svn_command ;;
     esac
     [ ! -z "${kak_client_env_TMUX}" ] && additional_flags="--expect $kak_opt_fzf_vertical_map --expect $kak_opt_fzf_horizontal_map"
     printf "%s\n" "fzf -kak-cmd %{cd $repo_root; edit -existing} -items-cmd %{$cmd} -fzf-args %{-m --expect $kak_opt_fzf_window_map $additional_flags} -post-action %{cd $current_path}"

--- a/rc/modules/fzf-cd.kak
+++ b/rc/modules/fzf-cd.kak
@@ -24,7 +24,7 @@ declare-option -docstring 'command to show list of directories in preview window
 Default value:
     tree -d
 ' \
-str cd_preview_cmd "tree -d {}"
+str cd_preview_command "tree -d {}"
 
 declare-option -docstring 'maximum amount of previewed directories' \
 int fzf_preview_dirs '300'
@@ -43,7 +43,7 @@ current path: $(pwd)}"
     esac
     if [ "$kak_opt_fzf_cd_preview" = "true" ]; then
         preview_flag="-preview"
-        preview="--preview '($kak_opt_cd_preview_cmd) 2>/dev/null | head -n $kak_opt_fzf_preview_dirs'"
+        preview="--preview '($kak_opt_cd_preview_command) 2>/dev/null | head -n $kak_opt_fzf_preview_dirs'"
     fi
     printf "%s\n" "fzf $preview_flag -kak-cmd %{change-directory} -items-cmd %{$items_command} -preview-cmd %{$preview} -post-action %{fzf-cd}"
 }}

--- a/rc/modules/fzf-cd.kak
+++ b/rc/modules/fzf-cd.kak
@@ -37,12 +37,9 @@ define-command -hidden fzf-cd %{ evaluate-commands %sh{
     tmux_height=$kak_opt_fzf_tmux_height
     printf '%s\n' "info -title %{fzf change directory} %{Change the server's working directory
 current path: $(pwd)}"
-
     case $kak_opt_fzf_cd_command in
-        find)
-            items_command="(echo .. && find . \( -path '*/.svn*' -o -path '*/.git*' \) -prune -o -type d -print)" ;;
-        *)
-            items_command=$kak_opt_fzf_cd_command ;;
+        (find) items_command="(echo .. && find . \( -path '*/.svn*' -o -path '*/.git*' \) -prune -o -type d -print)" ;;
+        (*)    items_command=$kak_opt_fzf_cd_command ;;
     esac
     if [ "$kak_opt_fzf_cd_preview" = "true" ]; then
         preview_flag="-preview"

--- a/rc/modules/fzf-file.kak
+++ b/rc/modules/fzf-file.kak
@@ -34,20 +34,14 @@ define-command -hidden fzf-file %{ evaluate-commands %sh{
         kak_opt_fzf_file_command="find"
     fi
     case $kak_opt_fzf_file_command in
-    find)
-        cmd="find -L . -type f" ;;
-    ag)
-        cmd="ag -l -f --hidden --one-device . " ;;
-    rg)
-        cmd="rg -L --hidden --files" ;;
-    fd)
-        cmd="fd --type f --follow" ;;
-    find*|ag*|rg*|fd*)
-        cmd=$kak_opt_fzf_file_command ;;
-    *)
-        items_executable=$(printf "%s\n" "$kak_opt_fzf_file_command" | grep -o -E "[[:alpha:]]+" | head -1)
-        printf "%s\n" "echo -markup '{Information}'Warning: '$executable'' is not supported by fzf.kak.'"
-        cmd=$kak_opt_fzf_file_command ;;
+        (find)              cmd="find -L . -type f" ;;
+        (ag)                cmd="ag -l -f --hidden --one-device . " ;;
+        (rg)                cmd="rg -L --hidden --files" ;;
+        (fd)                cmd="fd --type f --follow" ;;
+        (find*|ag*|rg*|fd*) cmd=$kak_opt_fzf_file_command ;;
+        (*)                 items_executable=$(printf "%s\n" "$kak_opt_fzf_file_command" | grep -o -E "[[:alpha:]]+" | head -1)
+                            printf "%s\n" "echo -markup '{Information}'Warning: '$executable'' is not supported by fzf.kak.'"
+                            cmd=$kak_opt_fzf_file_command ;;
     esac
 
     cmd="$cmd 2>/dev/null"

--- a/rc/modules/fzf-project.kak
+++ b/rc/modules/fzf-project.kak
@@ -49,16 +49,16 @@ define-command -hidden fzf-save-path-as-project-no-prompt %{ evaluate-commands %
     mkdir -p "${kak_opt_fzf_project_file%/*}"
     # portable version of `basename'
     base() {
-        filename=$1
+        filename="$1"
         case "$filename" in
-          */*[!/]*)
-            trail=${filename##*[!/]}
-            filename=${filename%%"$trail"}
-            base=${filename##*/} ;;
-          *[!/]*)
-            trail=${filename##*[!/]}
-            base=${filename%%"$trail"} ;;
-          *) base="/" ;;
+            (*/*[!/]*)
+                trail=${filename##*[!/]}
+                filename=${filename%%"$trail"}
+                base=${filename##*/} ;;
+            (*[!/]*)
+                trail=${filename##*[!/]}
+                base=${filename%%"$trail"} ;;
+            (*) base="/" ;;
         esac
         printf "%s\n" "${base}"
     }
@@ -84,16 +84,16 @@ fzf-add-project -file-completion -params 1..2 %{ evaluate-commands %sh{
     fi
     # portable version of `basename'
     base() {
-        filename=$1
+        filename="$1"
         case "$filename" in
-          */*[!/]*)
-            trail=${filename##*[!/]}
-            filename=${filename%%"$trail"}
-            base=${filename##*/} ;;
-          *[!/]*)
-            trail=${filename##*[!/]}
-            base=${filename%%"$trail"} ;;
-          *) base="/" ;;
+            (*/*[!/]*)
+                trail=${filename##*[!/]}
+                filename=${filename%%"$trail"}
+                base=${filename##*/} ;;
+            (*[!/]*)
+                trail=${filename##*[!/]}
+                base=${filename%%"$trail"} ;;
+            (*) base="/" ;;
         esac
         printf "%s\n" "${base}"
     }


### PR DESCRIPTION
**Breaking change**: yes
<!-- Please provide meaningful description about your contribution -->
**Description**:
Added way to configure which terminal command to use
Renamed variables that ended with `_cmd` to end with `_command`
Fixes #63
<!-- note that code will be reviewed and changes much likely will be requested -->
