### PR TITLE
Make fzf_preview option affect fzf-file command

### DIFF
--- a/rc/modules/fzf-file.kak
+++ b/rc/modules/fzf-file.kak
@@ -54,7 +54,11 @@ $kak_opt_fzf_vertical_map: open file in vertical split"
 
     printf "%s\n" "info -title 'fzf file' '$message$tmux_keybindings'"
     [ ! -z "${kak_client_env_TMUX}" ] && additional_flags="--expect $kak_opt_fzf_vertical_map --expect $kak_opt_fzf_horizontal_map"
-    printf "%s\n" "fzf -preview -kak-cmd %{edit -existing} -items-cmd %{$cmd} -fzf-args %{-m --expect $kak_opt_fzf_window_map $additional_flags}"
+
+    if [ "$kak_opt_fzf_cd_preview" = "true" ]; then
+        preview_flag="-preview"
+    fi
+    printf "%s\n" "fzf $preview_flag -kak-cmd %{edit -existing} -items-cmd %{$cmd} -fzf-args %{-m --expect $kak_opt_fzf_window_map $additional_flags}"
 }}
 
 §


### PR DESCRIPTION
**Breaking change**: no
<!-- Please provide meaningful description about your contribution -->
**Description**:

The `fzf-file` command previously ignored the `fzf_preview` option, so you weren't able to disable the preview. I copied some of the code that `fzf-cd` uses to check `fzf_preview` and adapted it for the `fzf-file` command.

This implementation may be incomplete (may not support a custom preview command).


<!-- note that code will be reviewed and changes much likely will be requested -->
