### PR TITLE
fix fzf_use_main_selection on multi-line

### DIFF
--- a/rc/fzf.kak
+++ b/rc/fzf.kak
@@ -145,6 +145,7 @@ fzf -params .. %{ evaluate-commands %sh{
 
     [ "${kak_opt_fzf_use_main_selection}" = "true" ] && \
     [ $(printf "%s" "${kak_selection}" | wc -m) -gt 1 ] && \
+    [ $(printf "%s" "${kak_selection}" | wc -l) -eq 1 ] && \
     default_query="-i -q ${kak_selection}"
 
     while [ $# -gt 0 ]; do


### PR DESCRIPTION
If your `kak_selection` has multiple lines and `fzf_use_main_selection` is true, then the preview window would not even show up. This fixes that error, only populating main selection if it's a single line.