### PR TITLE
Fix the open files in directory of current file feature

### DIFF
--- a/rc/modules/fzf-file.kak
+++ b/rc/modules/fzf-file.kak
@@ -59,6 +59,13 @@ define-command -hidden fzf-file -params 0..1 %{ evaluate-commands %sh{
     esac
 
     cmd="cd $search_dir; $cmd 2>/dev/null"
+    maybe_filter_param=""
+    if [ "$search_dir" != "." ]; then
+        # Since we cd-ed into search dir in $cmd, prefix the $search_dir path after fzf returns the results by using -filter switch of fzf.
+        # Kakoune either needs an absolute path or path relative to its pwd to edit a file. Since the pwd of $cmd and kakoune now differ,
+        # we cannot use a relative path, so we construct the absolute path by prefixing the $search_dir to the file outputted by fzf.
+        maybe_filter_param=$(printf "%s %s" "-filter" "%{perl -pe \"if (/${kak_opt_fzf_window_map:-ctrl-w}|${kak_opt_fzf_vertical_map:-ctrl-v}|${kak_opt_fzf_horizontal_map:-ctrl-s}|^$/) {} else {print \\\"$search_dir/\\\"\"}}")
+    fi
     message="Open single or multiple files.
 <ret>: open file in new buffer.
 ${kak_opt_fzf_window_map:-ctrl-w}: open file in new terminal"
@@ -69,7 +76,7 @@ ${kak_opt_fzf_vertical_map:-ctrl-v}: open file in vertical split"
     printf "%s\n" "info -title 'fzf file' '$message$tmux_keybindings'"
     [ -n "${kak_client_env_TMUX}" ] && additional_flags="--expect ${kak_opt_fzf_vertical_map:-ctrl-v} --expect ${kak_opt_fzf_horizontal_map:-ctrl-s}"
     [ "${kak_opt_fzf_file_preview:-}" = "true" ] && preview_flag="-preview"
-    printf "%s\n" "fzf $preview_flag -kak-cmd %{edit -existing} -items-cmd %{$cmd} -fzf-args %{-m --expect ${kak_opt_fzf_window_map:-ctrl-w} $additional_flags}"
+    printf "%s\n" "fzf $preview_flag $maybe_filter_param -kak-cmd %{edit -existing} -items-cmd %{$cmd} -fzf-args %{-m --expect ${kak_opt_fzf_window_map:-ctrl-w} $additional_flags}"
 }}
 
 §


### PR DESCRIPTION
Sorry for revisiting this feature again with another PR! In my excitement to get this merged, I actually did not test the feature fully. I was just looking at the candidate results in fzf (which were correct) and forgot to actually press enter on them to see if the file actually loaded in kakoune. (In an older cruder implementation it was fully working so I wrongly assume everything was going to be fine...)

**TL;DR** with this PR everything should work properly now. If you are able to quickly test this as a sanity check, I will greatly appreciate it.

---
Since we cd-ed into search dir in $cmd, prefix the $search_dir path
after fzf returns the results by using -filter switch of fzf.
Kakoune either needs an absolute path or path relative to its pwd
to edit a file. Since the pwd of $cmd and kakoune now differ,
we cannot use a relative path, so we construct the absolute path
by prefixing the $search_dir to the file outputted by fzf.