### PR TITLE
Simplify approach to providing an alternative fzf file find invocation

### DIFF
--- a/rc/modules/fzf-file.kak
+++ b/rc/modules/fzf-file.kak
@@ -4,6 +4,7 @@
 
 hook global ModuleLoaded fzf %{
     map global fzf -docstring "open file" 'f' '<esc>: require-module fzf-file; fzf-file<ret>'
+    map global fzf -docstring "open file using the alternative command" 'o' '<esc>: require-module fzf-file; fzf-file alternative-command<ret>'
     map global fzf -docstring "open file in dir of currently displayed file" 'F' '<esc>: require-module fzf-file; fzf-file buffile-dir<ret>'
 }
 
@@ -25,6 +26,25 @@ Default arguments:
 " \
 str fzf_file_command "find"
 
+declare-option -docstring "Alternate command to provide list of files to fzf.
+Just like the str option fzf_file_command. It allows you to provide a variant e.g. use
+another program or pass a different set of switches to your favorite file file command.
+Arguments are supported
+Supported tools:
+    <package>:           <value>:
+    GNU Find:            ""find""
+    The Silver Searcher: ""ag""
+    ripgrep:             ""rg""
+    fd:                  ""fd""
+
+Default arguments:
+    find: ""find -L . -type f""
+    ag:   ""ag -l -f --hidden --one-device .""
+    rg:   ""rg -L --hidden --files""
+    fd:   ""fd --type f --follow""
+" \
+str fzf_file_alternative_command "find"
+
 declare-option -docstring 'allow showing preview window while searching for file
 Default value:
     true
@@ -43,26 +63,22 @@ define-command -hidden fzf-file -params 0..2 %{ evaluate-commands %sh{
         search_dir=$(dirname "$kak_buffile")
     fi
 
+    if [ "$1" = "alternative-command" ] || [ "$2" = "alternative-command" ]; then
+        kak_opt_fzf_file_command=$kak_opt_fzf_file_alternative_command
+    fi
     if [ -z "$(command -v "${kak_opt_fzf_file_command%% *}")" ]; then
         printf "%s\n" "echo -markup '{Information}''$kak_opt_fzf_file_command'' is not installed. Falling back to ''find'''"
         kak_opt_fzf_file_command="find"
     fi
-    cmd_append=""
-    case "$1" in
-       (extra-switch=*) cmd_append="${1#extra-switch=}" ;;
-    esac
-    case "$2" in
-       (extra-switch=*) cmd_append="${2#extra-switch=}" ;;
-    esac
     case $kak_opt_fzf_file_command in
-        (find)              cmd="find -L . -type f $cmd_append" ;;
-        (ag)                cmd="ag -l -f --hidden --one-device $cmd_append . " ;;
-        (rg)                cmd="rg -L --hidden --files $cmd_append" ;;
-        (fd)                cmd="fd --type f --follow $cmd_append" ;;
-        (find*|ag*|rg*|fd*) cmd="$kak_opt_fzf_file_command $cmd_append";;
-        (*)                 items_executable=$(printf "%s\n" "$kak_opt_fzf_file_command $cmd_append" | grep -o -E "[[:alpha:]]+" | head -1)
+        (find)              cmd="find -L . -type f" ;;
+        (ag)                cmd="ag -l -f --hidden --one-device . " ;;
+        (rg)                cmd="rg -L --hidden --files" ;;
+        (fd)                cmd="fd --type f --follow" ;;
+        (find*|ag*|rg*|fd*) cmd=$kak_opt_fzf_file_command ;;
+        (*)                 items_executable=$(printf "%s\n" "$kak_opt_fzf_file_command" | grep -o -E "[[:alpha:]]+" | head -1)
                             printf "%s\n" "echo -markup %{{Information}Warning: '$items_executable' is not supported by fzf.kak.}"
-                            cmd="$kak_opt_fzf_file_command $cmd_append";;
+                            cmd=$kak_opt_fzf_file_command ;;
     esac
 
     cmd="cd $search_dir; $cmd 2>/dev/null"


### PR DESCRIPTION
- Revert some changes. Create a new str option `fzf_file_alternative_command`.
- Also provide a shortcut 'o' by default

Here is the sample kakrc configuration now using the simplified approach.

```kak
hook global ModuleLoaded fzf-file %{
    set global fzf_file_command "rg -L --files"
    set global fzf_file_alternative_command "rg -L --files --no-ignore"
}
```
-----------
P.S. As this commit reverts some changes of the previous commit cb07538a88dd51b1c03800d6c451d2d71e7b80a5 , it is also useful to see the following. 

https://github.com/andreyorst/fzf.kak/compare/95b12b1fe93c6db0441c61062823231a28eed037..a1012402af3db8411144877437697fb678424a24

The above link compares this PR with the commit
```
commit 95b12b1fe93c6db0441c61062823231a28eed037
Author: Andrey Listopadov <andreyorst@gmail.com>
Date:   Wed Mar 23 19:55:27 2022 +0300

    fzf-grep file preview
```

The above diff is probably simpler to review.