### PR TITLE
Center search results in preview window & remove preview line limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ When using fzf.kak inside `tmux`, the bottom pane is used for all `fzf` commands
 When the preview is turned on, the height of the `tmux` split is increased to provide more space.
 Split height can be configured with the `fzf_preview_tmux_height` variable.
 
-Amount of lines in the preview window can be changed with the `fzf_preview_lines` option.
+*NOTE:* The `fzf_preview_lines` option has been removed to accomodate automatically centering the location of match results.
 
 The preview feature can be disabled entirely by setting the `fzf_preview` option to `false`.
 

--- a/rc/fzf.kak
+++ b/rc/fzf.kak
@@ -26,10 +26,6 @@ Default value:
 ' \
 bool fzf_preview true
 
-declare-option -docstring 'amount of lines to pass to preview window
-Default value: 100' \
-int fzf_preview_lines 100
-
 declare-option -docstring 'preview window position.
 Supported values: up (top),  down (bottom), left, right, auto
 
@@ -183,7 +179,7 @@ fzf -params .. %{ evaluate-commands %sh{
                 (rouge)     highlight_cmd="rougify {}" ;;
                 (*)         highlight_cmd="${kak_opt_fzf_highlight_command}" ;;
             esac
-            preview_cmd="--preview '(${highlight_cmd} || cat {}) 2>/dev/null | head -n ${kak_opt_fzf_preview_lines:-}' --preview-window=\${pos}"
+            preview_cmd="--preview '(${highlight_cmd} || cat {}) 2>/dev/null' --preview-window=\${pos}:+2-/2"
         fi
     fi
 

--- a/rc/modules/fzf-grep.kak
+++ b/rc/modules/fzf-grep.kak
@@ -62,7 +62,7 @@ ${kak_opt_fzf_vertical_map:-ctrl-v}: open search result in vertical split"
 
     preview_cmd=""
     if [ "${kak_opt_fzf_grep_preview:-}" = "true" ]; then
-        preview_cmd="-preview -preview-cmd %{--preview '(${highlight_cmd} || cat {1}) 2>/dev/null | head -n ${kak_opt_fzf_preview_lines:-}' --preview-window=\${pos}}"
+        preview_cmd="-preview -preview-cmd %{--preview '(${highlight_cmd} || cat {1}) 2>/dev/null' --preview-window=\${pos}:+{2}-/2}"
     fi
 
     printf "%s\n" "info -title '${title}' '${message}${tmux_keybindings}'"


### PR DESCRIPTION
This is intended to scroll to the location of a match result and center it in the preview window.

Before: 

![before_preview](https://user-images.githubusercontent.com/9307830/173529720-8c94d100-3c86-4e10-93b1-0e99b735ebcf.png)

After:

![after_preview](https://user-images.githubusercontent.com/9307830/173529745-f934fdf8-f07b-44f3-8618-c970c07abef5.png)
